### PR TITLE
Specify Galaxy ingress settings needed by Leo

### DIFF
--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -23,7 +23,16 @@ galaxy:
     storageClass: "nfs"
     size: "300Gi"
   ingress:
-    enabled: false
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+      nginx.ingress.kubernetes.io/auth-tls-secret: "{{.Release.Namespace}}/ca-secret"
+      nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
+      nginx.ingress.kubernetes.io/auth-tls-verify-depth: "1"
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    tls:
+      - secretName: "tls-secret"
   postgresql:
     persistence:
       storageClass: "standard"


### PR DESCRIPTION
Specifies nginx ingress with [client certificate authentication](https://kubernetes.github.io/ingress-nginx/examples/auth/client-certs/), which Leo will use.

Leo will set ingress host and path dynamically via `--set` parameter.