### PR TITLE
add role and role binding to chart

### DIFF
--- a/galaxykubeman/templates/_helpers.yml
+++ b/galaxykubeman/templates/_helpers.yml
@@ -29,3 +29,7 @@ Create chart name and version as used by the chart label.
 {{- define "galaxykubeman.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "galaxykubeman.roleName" -}}
+{{- default (printf "%s-%s" .Release.Namespace "rbac") .Values.rbac.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Release.Namespace }}-rbac
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["", "extensions", "apps"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["*"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ .Release.Namespace }}-rbac-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.rbac.ksa }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Namespace }}-rbac

--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -2,7 +2,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Namespace }}-rbac
+  name: {{ include "galaxykubeman.roleName" . }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: ["", "extensions", "apps"]
@@ -28,7 +28,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Namespace }}-rbac
+  name: {{ include "galaxykubeman.roleName" . }}
 
 ---
 {{- end -}}

--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac }}
+{{- if .Values.rbac.enabled }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -19,7 +19,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ .Release.Namespace }}-rbac-binding
+  name: {{ include "galaxykubeman.roleName" . }}-binding
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount

--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -22,9 +23,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.rbac.ksa }}
+    name: {{ .Values.rbac.serviceAccount }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ .Release.Namespace }}-rbac
+
+---
+{{- end -}}

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -55,4 +55,4 @@ galaxy:
   #       key: WORKSPACE_NAME
 
 rbac:
-  # ksa: leo-created-ksa
+  # serviceAccount: leo-created-ksa

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -55,4 +55,5 @@ galaxy:
   #       key: WORKSPACE_NAME
 
 rbac:
+  enabled: true
   # serviceAccount: leo-created-ksa

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -53,3 +53,6 @@ galaxy:
   #     configMapKeyRef:
   #       name: "{{.Release.Name}}-[galaxykubeman|leo]-configs"
   #       key: WORKSPACE_NAME
+
+rbac:
+  # ksa: leo-created-ksa


### PR DESCRIPTION
Adding Kubernetes `Role` and `RoleBinding` to the galaxy kubeman chart because they are galaxy specific. If anything needs to change about either, the Galaxy team can do that easily. 