### PR TITLE
Change image to use `anvil-aug26` tag

### DIFF
--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -27,6 +27,9 @@ cvmfs:
       enabled: false
 
 galaxy:
+  image:
+    repository: galaxy/galaxy-k8s
+    tag: anvil-aug26
   persistence:
     accessMode: "ReadWriteMany"
     storageClass: "nfs"


### PR DESCRIPTION
This image is a snapshot of `20.09` from Galaxy's `dev` branch. Source code for this branch is at: https://github.com/galaxyproject/galaxy/tree/anvil. This image includes the Anvil branding changes, and the single-user DB fix. 