### PR TITLE
Accomodate empty persistence dict

### DIFF
--- a/galaxykubeman/templates/persistence.yaml
+++ b/galaxykubeman/templates/persistence.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $entry := .Values.persistence -}}
-
+{{- if $entry -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -75,5 +75,6 @@ spec:
 
 ---
 
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Fixes 
```
Error: template: galaxykubeman/templates/persistence.yaml:6:17: executing "galaxykubeman/templates/persistence.yaml" at <$entry.name>: can't evaluate field name in type interface {}
```
when `persistence={}`