### PR TITLE
update image to use galaxy-anvil:20.09.1

### DIFF
--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -28,8 +28,8 @@ cvmfs:
 
 galaxy:
   image:
-    repository: galaxy/galaxy-k8s
-    tag: anvil-aug26
+    repository: galaxy/galaxy-anvil
+    tag: 20.09.1
   persistence:
     accessMode: "ReadWriteMany"
     storageClass: "nfs"


### PR DESCRIPTION
This has the startup speed fixes ported over (not merged into -dev yet) as well as all the other customizations rebased on top of current `dev`, which will soon be the 20.09 freeze.