### PR TITLE
Update rbac APIs to v1

### DIFF
--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.enabled }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "galaxykubeman.roleName" . }}
   namespace: {{ .Release.Namespace }}
@@ -20,7 +20,7 @@ rules:
 ---
 
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "galaxykubeman.roleName" . }}-binding
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta will no longer be available with K8s 1.22 (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122).

Friends with https://github.com/galaxyproject/galaxy-helm/pull/367.