### PR TITLE
Consolidate duplicate postgresql keys in the values.yml file

### DIFF
--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -196,6 +196,8 @@ galaxy:
           default_resource_set: small
   postgresql:
     deploy: true
+    persistence:
+      storageClass: "standard"
     # nodeSelector: "cloud.google.com/gke-nodepool: good-pool"
   image:
     repository: galaxy/galaxy-anvil
@@ -216,9 +218,6 @@ galaxy:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
     tls:
       - secretName: "tls-secret"
-  postgresql:
-    persistence:
-      storageClass: "standard"
   influxdb:
     enabled: false
   extraEnv: []


### PR DESCRIPTION
The `postgresql` key appears twice in the `galaxy` section of the `values.yml` file.  However, the [YAML specification](https://yaml.org/spec/1.2.2/#3211-nodes) requires that keys be unique. So either:

1. The second `postgresql` section is overwriting the first, or
2. We are relying on non-standard behaviour that may change in the future.

This PR consolidates the two sections into a single entry to remedy the above two situations.