### PR TITLE
Anvil 23.1

### DIFF
--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: "23.1"
 description: A chart for deploying and managing a single Galaxy out-of-the-box instance on Managed Kubernetes clusters (GKE)
 name: galaxykubeman
-version: 2.8.0
+version: 2.7.0
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:
   - name: nfs-server-provisioner

--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 type: application
-appVersion: "23.0"
+appVersion: "23.1"
 description: A chart for deploying and managing a single Galaxy out-of-the-box instance on Managed Kubernetes clusters (GKE)
 name: galaxykubeman
-version: 2.7.0
+version: 2.8.0
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:
   - name: nfs-server-provisioner

--- a/galaxykubeman/templates/config-setup-galaxy.yaml
+++ b/galaxykubeman/templates/config-setup-galaxy.yaml
@@ -11,7 +11,7 @@ data:
   galaxy.yml: |
     {{- .Values.galaxy | toYaml | nindent 4 }}
   setup_galaxy.sh: |
-    helm repo add anvil https://raw.githubusercontent.com/cloudve/helm-charts/anvil/
+    helm repo add anvil {{ .Values.galaxy.chart.repository }}
     helm repo update
     helm upgrade --install -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --set cvmfs.storageClassName="{{ .Release.Name }}-cvmfs" --wait --timeout=15m0s
   check_galaxy.sh: |

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -68,7 +68,9 @@ galaxyInstallJob:
     timeoutSeconds: 10
 
 galaxy:
-  version: 5.7.1-anvil.2
+  version: 5.7.6-anvil.1
+  chart:
+    repository: https://raw.githubusercontent.com/cloudve/helm-charts/anvil/
   jobs:
     priorityClass:
       existingClass: "{{ .Release.Namespace }}-priority-class"
@@ -80,7 +82,7 @@ galaxy:
       memory: 60 # in G
   image:
     repository: quay.io/galaxyproject/galaxy-anvil
-    tag: "23.0"
+    tag: "23.1"
   persistence:
     accessMode: "ReadWriteMany"
     storageClass: "nfs"


### PR DESCRIPTION
Update the chart for Galaxy 23.1

This shouldn't be merged until the `galaxy-helm:5.7.6-anvil.1` chart is available.