### PR TITLE
Update base css path

### DIFF
--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -407,7 +407,7 @@ galaxy:
         <html lang="en">
             <head>
                 <meta charset="utf-8" />
-                <link rel="stylesheet" href="style/base.css" type="text/css" />
+                <link rel="stylesheet" href="dist/base.css" type="text/css" />
             </head>
             <body class="m-0">
                 <div class="py-4">


### PR DESCRIPTION
As of Galaxy 23.1 `style/base.css` no longer works and we should use `dist/base.css` instead. 