### PR TITLE
YAML document separators

### DIFF
--- a/galaxykubeman/templates/config-setup-galaxy.yaml
+++ b/galaxykubeman/templates/config-setup-galaxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-galaxykubeman-setup-galaxy

--- a/galaxykubeman/templates/configs.yaml
+++ b/galaxykubeman/templates/configs.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.configs }}
+---
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-galaxykubeman-configs
@@ -15,6 +16,5 @@ data:
     {{- $entry | nindent 8 }}
   {{- end -}}
   {{- end }}
----
 {{- end -}}
 

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/galaxykubeman/templates/job-setup-galaxy.yaml
+++ b/galaxykubeman/templates/job-setup-galaxy.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/galaxykubeman/templates/persistence-restore.yaml
+++ b/galaxykubeman/templates/persistence-restore.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.restore.persistence.nfs.galaxy.pvcID -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -19,8 +20,8 @@ spec:
       storage: {{ .Values.galaxy.persistence.size | quote }}
   volumeMode: Filesystem
   volumeName: "pvc-{{.Values.restore.persistence.nfs.galaxy.pvcID}}"
----
 {{ if .Values.restore.persistence.nfs.galaxy.deployVolume -}}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -58,6 +59,5 @@ spec:
   claimRef:
     namespace: {{ .Release.Namespace }}
     name: {{ .Release.Name }}-galaxy-galaxy-pvc
----
 {{ end -}}
 {{ end -}}

--- a/galaxykubeman/templates/persistence.yaml
+++ b/galaxykubeman/templates/persistence.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $entry := .Values.persistence -}}
 {{- if $entry -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -42,10 +43,8 @@ spec:
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
 
----
-
 {{ if $entry.persistentVolume }}
-
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -94,8 +93,6 @@ spec:
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
-
----
 
 {{ end -}}
 {{- end -}}

--- a/galaxykubeman/templates/priority-class.yaml
+++ b/galaxykubeman/templates/priority-class.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:

--- a/galaxykubeman/templates/rbac.yaml
+++ b/galaxykubeman/templates/rbac.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.enabled }}
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -18,7 +19,6 @@ rules:
     verbs: ["*"]
 
 ---
-
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -32,6 +32,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "galaxykubeman.roleName" . }}
-
----
 {{- end -}}

--- a/galaxykubeman/templates/resource-quota.yaml
+++ b/galaxykubeman/templates/resource-quota.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ResourceQuota
 metadata:

--- a/galaxykubeman/templates/secrets.yaml
+++ b/galaxykubeman/templates/secrets.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.secrets }}
+---
 apiVersion: v1
 metadata:
   name: {{ .Release.Name }}-galaxykubeman-secrets
@@ -16,5 +17,4 @@ stringData:
     {{ $secentry | indent 8 -}}
   {{- end -}}
   {{- end }}
----
 {{- end -}}


### PR DESCRIPTION
According to the [YAML specification](https://yaml.org/spec/1.2.2/) three dashes are used to separate YAML directives from the document content and are also used to mark the start of a document if the file (stream) contains more than one YAML document. However, several templates include a document separator at the end of the file, which can cause odd syntax problems depending on the order Helm arranges the templates.

This PR adds triple dashes to the top of each YAML document and removes extraneous appearances elsewhere. The document separator is optional if a file only contains one YAML document, but I have added them to all templates for completeness.