### PR TITLE
Update NFS Ganesha to version 1.8.0

### DIFF
--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.p
 dependencies:
   - name: nfs-server-provisioner
     repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
-    version: 1.5.0
+    version: 1.8.0
     alias: nfs
   - name: galaxy-cvmfs-csi
     repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/


### PR DESCRIPTION
The current version used (1.5.0) and version 1.8.0 seems to fix problems that were present in 1.6.0 and 1.7.0 (I.e. the charts were not published).

Closes #80 