### PR TITLE
Updates to install galaxy-deps separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # Galaxy on Kubernetes Management (GalaxyKubeMan) Helm Chart
 Helm chart for GalaxyKubeMan (GKM) used for deploying Galaxy on GKE/AnVIL.
 
-## Creating a cluster and deploying Galaxy
+## Creating a GKE cluster and deploying dependencies
 
-The following command should get everything set up. Start by launching a GKE
-cluster, then install a dependencies chart that deploys necessary operators,
-create a persistent disk, and then install GKM, which will install Galaxy.
-
-The `sample-values.yaml` file contains the values to deploy a test/dev version
-of GKM. In addition, you will need to copy `sample-auth.yaml` to the `templates`
-folder before deploying a dev instance. Also, update the values of `persistence.postgres.persistentVolume.extraSpec.csi.volumeHandle` to the correct project id.
+Start by launching a GKE cluster, then install the dependencies chart that deploys
+necessary operators, and then create persistent disks.
 
 ```console
-gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b --addons=GcePersistentDiskCsiDriver"
+gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
+
 
 helm repo add cloudve https://raw.githubusercontent.com/CloudVE/helm-charts/master/
 helm repo update
-helm install --create-namespace -n "galaxy-deps" galaxy-deps cloudve/galaxy-deps --set cvmfs.cvmfscsi.nodeplugin.priorityClassName=""
+helm install --create-namespace -n "galaxy-deps" galaxy-deps cloudve/galaxy-deps --set cvmfs.cvmfscsi.nodeplugin.priorityClassName="" --set postgresql.deploy=false
 
 gcloud compute disks create "nfs-pd" --size 300Gi --zone "us-east1-b"
 gcloud compute disks create "postgres-pd" --size 10Gi --zone "us-east1-b"
+```
 
+It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
+
+## Deploying a new Galaxy instance
+
+Once the cluster is created, you can deploy a new Galaxy instance. The
+`sample-values.yaml` file contains sample values to deploy a test/dev version
+with no/minimal configuration. Consider the following changes:
+
+- If you changed the names or the persistent disks from the instructions above,
+just update those values in `persistence.[nfs,
+postgres].persistentVolume.extraSpec.gcePersistentDisk.pdName`;
+- Set the value of `galaxy.persistence.existingDatabase` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
+- Set the value of `galaxy.persistence.galaxyExistingSecret` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
+
+Then run the following commands:
+
+```console
 git clone https://github.com/galaxyproject/galaxykubeman-helm
 cd galaxykubeman-helm/galaxykubeman
 cp sample-auth.yaml templates/auth.yaml
@@ -28,20 +42,41 @@ helm dependency update
 helm upgrade --install --create-namespace -n gkmns gkm . --values sample-values.yaml --wait --wait-for-jobs
 ```
 
-It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
+**Note:** If you will want to redeploy this instance, before deleting it, make sure to record the ID of the Galaxy PVC.
 
-### Deploying 2nd Galaxy instance
+## Redeploying a Galaxy instance
+If you want to redeploy a Galaxy instance, meaning create a new instance but
+with data from an earlier installation, it is necessary to update the following
+values before installing the chart:
 
-To deploy a second Galaxy instance on the same cluster, you can use
-`sample-values-2nd-deployment.yaml` to provide the necessary configurations.
-Before running the following commands, add a new node pool to the existing GKE
-cluster, named `pool-2`, then update the values of `persistence.postgres.persistentVolume.extraSpec.csi.volumeHandle` to the correct project id, and then run the following commands:
+- Set `restore.persistence.nfs.galaxy.pvcID` to the PVC ID of the old PVC from
+the previous Galaxy instance;
+- Set `galaxy.persistence..existingClaim` to `{{release-name}}-galaxy-galaxy-pvc`. You must use a literal string here, and not a template variable;
+- Set `galaxy.persistence.storageClass to -
+
+Then run the `helm upgrade` command again with the same parameters as above.
+
+## Deploying 2nd Galaxy instance on the same cluster
+
+To deploy a second Galaxy instance on the same cluster, first add a node pool to the cluster (call is `pool-2` if you want to minimize changes to the sample values) as well as create a second set of GCP persistent disks:
 
 ```console
 gcloud compute disks create "nfs-pd-2" --size 300Gi --zone "us-east1-b"
 gcloud compute disks create "postgres-pd-2" --size 10Gi --zone "us-east1-b"
+```
 
+Sample values are available in `sample-values-2nd-deployment.yaml` with the
+necessary configurations. Consider the following values changes:
 
+- If you changed the names of persistent disks, update `persistence.[nfs,
+postgres].persistentVolume.extraSpec.gcePersistentDisk.pdName` to the names of
+your GCP persistent disks;
+- Set the value of `galaxy.persistence.existingDatabase` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
+- Set the value of `galaxy.persistence.galaxyExistingSecret` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
+
+Then run the following commands:
+
+```console
 helm upgrade --install --create-namespace -n gkmns2 gkm2 . --values sample-values-2nd-deployment.yaml --wait --wait-for-jobs
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Galaxy on Kubernetes Management (GalaxyKubeMan) Helm Chart
 Helm chart for GalaxyKubeMan (GKM) used for deploying Galaxy on GKE/AnVIL.
 
-## TL;DR on GKE
+## Creating a cluster and deploying Galaxy
 
-We first launch a cluster, then install a dependencies chart that deploys
-necessary operators, create a persistent disk, and then install GKM, which will
-install Galaxy.
+The following command should get everything set up. Start by launching a GKE
+cluster, then install a dependencies chart that deploys necessary operators,
+create a persistent disk, and then install GKM, which will install Galaxy.
 
 The `sample-values.yaml` file contains the values to deploy a test/dev version
 of GKM. In addition, you will need to copy `sample-auth.yaml` to the `templates`
@@ -24,10 +24,27 @@ git clone https://github.com/galaxyproject/galaxykubeman-helm
 cd galaxykubeman-helm/galaxykubeman
 cp sample-auth.yaml templates/auth.yaml
 helm dependency update
-helm upgrade --install --create-namespace -n gkmns gkm . --values sample_values.yaml --wait --wait-for-jobs
+helm upgrade --install --create-namespace -n gkmns gkm . --values sample-values.yaml --wait --wait-for-jobs
 ```
 
 It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
+
+### Deploying 2nd Galaxy instance
+
+To deploy a second Galaxy instance on the same cluster, you can use
+`sample-values-2nd-deployment.yaml` to provide the necessary configurations.
+Before running the following commands, add a new node pool to the existing GKE
+cluster, named `pool-2`, then run the following commands:
+
+```console
+gcloud compute disks create "nfs-pd-2" --size 300Gi --zone "us-east1-b"
+
+helm upgrade --install --create-namespace -n gkmns2 gkm2 . --values sample-values-2nd-deployment.yaml --wait --wait-for-jobs
+```
+
+It will take a few minutes for the second Galaxy instance to be ready. The
+instance will be deployed It will be available at http://[galaxy-nginx-2 service
+external IP]/galaxy/.
 
 ## Leo updates
 When the GKM chart version changes, need to make a PR to

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Helm chart for GalaxyKubeMan (GKM) used for deploying Galaxy on GKE/AnVIL.
 
 ## Creating a GKE cluster and deploying dependencies
 
-Start by launching a GKE cluster, then install the dependencies chart that deploys
-necessary operators, and then create persistent disks.
+Start by launching a GKE cluster, then install the Galaxy dependencies chart that deploys
+necessary operators, as well as create persistent disks.
 
 ```console
 gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
@@ -18,8 +18,6 @@ gcloud compute disks create "nfs-pd" --size 300Gi --zone "us-east1-b"
 gcloud compute disks create "postgres-pd" --size 10Gi --zone "us-east1-b"
 ```
 
-It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
-
 ## Deploying a new Galaxy instance
 
 Once the cluster is created, you can deploy a new Galaxy instance. The
@@ -27,10 +25,16 @@ Once the cluster is created, you can deploy a new Galaxy instance. The
 with no/minimal configuration. Consider the following changes:
 
 - If you changed the names or the persistent disks from the instructions above,
-just update those values in `persistence.[nfs,
-postgres].persistentVolume.extraSpec.gcePersistentDisk.pdName`;
-- Set the value of `galaxy.persistence.existingDatabase` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
-- Set the value of `galaxy.persistence.galaxyExistingSecret` to `{{ release-name }}-postgresql` using the string literal, and not a template variable.
+  just update those values in `persistence.[nfs,
+  postgres].persistentVolume.extraSpec.gcePersistentDisk.pdName`;
+- If you plan on changing the release name from `gkm` used in the helm command
+  below, set the value of `galaxy.persistence.existingDatabase` to `{{
+  release-name }}-postgresql` using the string literal, and not a template
+  variable.
+- If you plan on changing the release name from `gkm` used in the helm command
+  below, set the value of `galaxy.persistence.galaxyExistingSecret` to `{{
+  release-name }}-postgresql` using the string literal, and not a template
+  variable.
 
 Then run the following commands:
 
@@ -42,7 +46,9 @@ helm dependency update
 helm upgrade --install --create-namespace -n gkmns gkm . --values sample-values.yaml --wait --wait-for-jobs
 ```
 
-**Note:** If you will want to redeploy this instance, before deleting it, make sure to record the ID of the Galaxy PVC.
+It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
+
+**Note:** If you will want to redeploy this instance (ie, keep the data), before deleting it, make sure to record the ID of the Galaxy PVC.
 
 ## Redeploying a Galaxy instance
 If you want to redeploy a Galaxy instance, meaning create a new instance but

--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
 # Galaxy on Kubernetes Management (GalaxyKubeMan) Helm Chart
-Helm chart for Galaxy KubeMan used for deploying Galaxy with NFS (for a
-multi-node shared filesystem), CVMFS (or S3FS) (for Galaxy tool and reference data), and
-CloudMan (for managing the Galaxy Kubernetes deployment).
+Helm chart for GalaxyKubeMan (GKM) used for deploying Galaxy on GKE/AnVIL.
 
 ## TL;DR on GKE
 
+We first launch a cluster, then install a dependencies chart that deploys
+necessary operators, create a persistent disk, and then install GKM, which will
+install Galaxy.
+
+The `sample-values.yaml` file contains the values to deploy a test/dev version
+of GKM. In addition, you will need to copy `sample-auth.yaml` to the `templates`
+folder before deploying a dev instance.
+
 ```console
-gcloud container clusters create example-gke-cluster --cluster-version="1.24" --no-enable-autorepair --disk-size=100 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
+gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
+
+helm repo add cloudve https://raw.githubusercontent.com/CloudVE/helm-charts/master/
+helm repo update
+helm install --create-namespace -n "galaxy-deps" galaxy-deps cloudve/galaxy-deps --set cvmfs.cvmfscsi.nodeplugin.priorityClassName=""
+
+gcloud compute disks create "nfs-pd" --size 300Gi --zone "us-east1-b"
+
 git clone https://github.com/galaxyproject/galaxykubeman-helm
 cd galaxykubeman-helm/galaxykubeman
+cp sample-auth.yaml templates/auth.yaml
 helm dependency update
-helm install --create-namespace --namespace mynamespace desired-release-name . --wait --wait-for-jobs
+helm upgrade --install --create-namespace -n gkmns gkm . --values sample_values.yaml --wait --wait-for-jobs
 ```
+
+It will take about 5 minutes for the Galaxy instance to be ready. It will be available at http://[galaxy-nginx service external IP]/galaxy/.
 
 ## Leo updates
 When the GKM chart version changes, need to make a PR to

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ create a persistent disk, and then install GKM, which will install Galaxy.
 
 The `sample-values.yaml` file contains the values to deploy a test/dev version
 of GKM. In addition, you will need to copy `sample-auth.yaml` to the `templates`
-folder before deploying a dev instance.
+folder before deploying a dev instance. Also, update the values of `persistence.postgres.persistentVolume.extraSpec.csi.volumeHandle` to the correct project id.
 
 ```console
-gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
+gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b --addons=GcePersistentDiskCsiDriver"
 
 helm repo add cloudve https://raw.githubusercontent.com/CloudVE/helm-charts/master/
 helm repo update
 helm install --create-namespace -n "galaxy-deps" galaxy-deps cloudve/galaxy-deps --set cvmfs.cvmfscsi.nodeplugin.priorityClassName=""
 
 gcloud compute disks create "nfs-pd" --size 300Gi --zone "us-east1-b"
+gcloud compute disks create "postgres-pd" --size 10Gi --zone "us-east1-b"
 
 git clone https://github.com/galaxyproject/galaxykubeman-helm
 cd galaxykubeman-helm/galaxykubeman
@@ -34,10 +35,12 @@ It will take about 5 minutes for the Galaxy instance to be ready. It will be ava
 To deploy a second Galaxy instance on the same cluster, you can use
 `sample-values-2nd-deployment.yaml` to provide the necessary configurations.
 Before running the following commands, add a new node pool to the existing GKE
-cluster, named `pool-2`, then run the following commands:
+cluster, named `pool-2`, then update the values of `persistence.postgres.persistentVolume.extraSpec.csi.volumeHandle` to the correct project id, and then run the following commands:
 
 ```console
 gcloud compute disks create "nfs-pd-2" --size 300Gi --zone "us-east1-b"
+gcloud compute disks create "postgres-pd-2" --size 10Gi --zone "us-east1-b"
+
 
 helm upgrade --install --create-namespace -n gkmns2 gkm2 . --values sample-values-2nd-deployment.yaml --wait --wait-for-jobs
 ```

--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -10,6 +10,3 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
     version: 1.8.0
     alias: nfs
-  - name: galaxy-deps
-    repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
-    version: 1.0.0

--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 type: application
-appVersion: "24.2.0"
+appVersion: "25.0"
 description: A chart for deploying and managing a single Galaxy out-of-the-box instance on Managed Kubernetes clusters (GKE)
 name: galaxykubeman
 version: 3.0.0

--- a/galaxykubeman/Chart.yaml
+++ b/galaxykubeman/Chart.yaml
@@ -10,3 +10,6 @@ dependencies:
     repository: https://kubernetes-sigs.github.io/nfs-ganesha-server-and-external-provisioner/
     version: 1.8.0
     alias: nfs
+  - name: postgresql
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: ~16.6.6

--- a/galaxykubeman/sample-auth.yaml
+++ b/galaxykubeman/sample-auth.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-gkm-cm-svc-account
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-gkm-cm-role-binding
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-gkm-cm-svc-account
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/galaxykubeman/sample-values-2nd-deployment.yaml
+++ b/galaxykubeman/sample-values-2nd-deployment.yaml
@@ -62,13 +62,13 @@ persistence:
     persistentVolume:
       extraSpec:
         gcePersistentDisk:
-          pdName: "ea-tmp-nfs-pd-2"
+          pdName: "nfs-pd-2"
   postgres:
     name: "galaxy-postgres-2"
     persistentVolume:
       extraSpec:
         gcePersistentDisk:
-          pdName: "ea-tmp-postgres-pd-2"
+          pdName: "postgres-pd-2"
 
 rbac:
   serviceAccount: gkm2-gkm-cm-svc-account

--- a/galaxykubeman/sample-values-2nd-deployment.yaml
+++ b/galaxykubeman/sample-values-2nd-deployment.yaml
@@ -33,9 +33,9 @@ galaxy:
         affinity:
           nodeSelector:
             "cloud.google.com/gke-nodepool": "pool-2"
-    persistence:
-      storageClass: "nfs-gkmns-2"
-      size: 2Gi
+        storage:
+          pvcTemplate:
+            volumeName: "galaxy-postgres-2-pv"
   rabbitmq:
     nodeSelector:
       "cloud.google.com/gke-nodepool": "pool-2"
@@ -63,6 +63,13 @@ persistence:
       extraSpec:
         gcePersistentDisk:
           pdName: "nfs-pd-2"
+  postgres:
+    name: "galaxy-postgres-2"
+    persistentVolume:
+      extraSpec:
+        csi:
+          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/postgres-pd-2"
+
 
 rbac:
   serviceAccount: gkm2-gkm-cm-svc-account

--- a/galaxykubeman/sample-values-2nd-deployment.yaml
+++ b/galaxykubeman/sample-values-2nd-deployment.yaml
@@ -27,15 +27,8 @@ galaxy:
     storageClass: "nfs-gkmns-2"
     size: "200Gi"
   postgresql:
-    galaxyDatabasePassword: galaxypassword
-    operator:
-      operatorSpecExtra:
-        affinity:
-          nodeSelector:
-            "cloud.google.com/gke-nodepool": "pool-2"
-        storage:
-          pvcTemplate:
-            volumeName: "galaxy-postgres-2-pv"
+    existingDatabase: gkm2-postgresql
+    galaxyExistingSecret: gkm2-postgresql
   rabbitmq:
     nodeSelector:
       "cloud.google.com/gke-nodepool": "pool-2"
@@ -47,6 +40,13 @@ galaxy:
     annotations: {}
     ingressClassName: ""
     tls: []
+
+postgresql:
+  primary:
+    nodeSelector:
+      "cloud.google.com/gke-nodepool": "pool-2"
+    persistence:
+      existingClaim: "galaxy-postgres-2-pvc"
 
 nfs:
   nodeSelector:
@@ -62,14 +62,13 @@ persistence:
     persistentVolume:
       extraSpec:
         gcePersistentDisk:
-          pdName: "nfs-pd-2"
+          pdName: "ea-tmp-nfs-pd-2"
   postgres:
     name: "galaxy-postgres-2"
     persistentVolume:
       extraSpec:
-        csi:
-          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/postgres-pd-2"
-
+        gcePersistentDisk:
+          pdName: "ea-tmp-postgres-pd-2"
 
 rbac:
   serviceAccount: gkm2-gkm-cm-svc-account

--- a/galaxykubeman/sample-values-2nd-deployment.yaml
+++ b/galaxykubeman/sample-values-2nd-deployment.yaml
@@ -28,9 +28,11 @@ galaxy:
     size: "200Gi"
   postgresql:
     galaxyDatabasePassword: galaxypassword
-    # FIXME: nodeSelector is not working for postgresql?
-    # nodeSelector:
-    #   "cloud.google.com/gke-nodepool": "pool-2"
+    operator:
+      operatorSpecExtra:
+        affinity:
+          nodeSelector:
+            "cloud.google.com/gke-nodepool": "pool-2"
     persistence:
       storageClass: "nfs-gkmns-2"
       size: 2Gi

--- a/galaxykubeman/sample-values-2nd-deployment.yaml
+++ b/galaxykubeman/sample-values-2nd-deployment.yaml
@@ -1,0 +1,66 @@
+galaxy:
+  service:
+    type: LoadBalancer
+    port: 80
+  configs:
+    "galaxy.yml":
+      galaxy:
+        admin_users: admin@cloudve.org
+        master_api_key: galaxypassword
+        single_user: admin@cloudve.org
+    "job_conf.yml":
+      runners:
+        k8s:
+          k8s_node_selector: "cloud.google.com/gke-nodepool: pool-2"
+  jobs:
+    rules:
+      # Used during development to ensure jobs will run on smaller instances
+      tpv_rules_local.yml:
+        destinations:
+          k8s:
+            max_cores: 2
+            # Memory must be an integer value, will be in Gi units
+            max_mem: 16
+  nodeSelector:
+    "cloud.google.com/gke-nodepool": "pool-2"
+  persistence:
+    storageClass: "nfs-gkmns-2"
+    size: "200Gi"
+  postgresql:
+    galaxyDatabasePassword: galaxypassword
+    # FIXME: nodeSelector is not working for postgresql?
+    # nodeSelector:
+    #   "cloud.google.com/gke-nodepool": "pool-2"
+    persistence:
+      storageClass: "nfs-gkmns-2"
+      size: 2Gi
+  rabbitmq:
+    nodeSelector:
+      "cloud.google.com/gke-nodepool": "pool-2"
+    persistence:
+      storageClassName: "nfs-gkmns-2"
+      # FIXME: Setting the size for rabbitmq is not working?
+      # size: 1Gi
+  ingress:
+    annotations: {}
+    ingressClassName: ""
+    tls: []
+
+nfs:
+  nodeSelector:
+    "cloud.google.com/gke-nodepool": "pool-2"
+  persistence:
+    existingClaim: "galaxy-nfs-2-pvc"
+  storageClass:
+    name: "nfs-gkmns-2"
+
+persistence:
+  nfs:
+    name: "galaxy-nfs-2"
+    persistentVolume:
+      extraSpec:
+        gcePersistentDisk:
+          pdName: "nfs-pd-2"
+
+rbac:
+  serviceAccount: gkm2-gkm-cm-svc-account

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -28,9 +28,11 @@ galaxy:
     size: "200Gi"
   postgresql:
     galaxyDatabasePassword: galaxypassword
-    # FIXME: nodeSelector is not working for postgresql?
-    # nodeSelector:
-    #   "cloud.google.com/gke-nodepool": "default-pool"
+    operator:
+      operatorSpecExtra:
+        affinity:
+          nodeSelector:
+            "cloud.google.com/gke-nodepool": "default-pool"
     persistence:
       storageClass: "nfs-gkmns"
       size: 2Gi

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -1,0 +1,65 @@
+galaxy:
+  service:
+    type: LoadBalancer
+    port: 80
+  configs:
+    "galaxy.yml":
+      galaxy:
+        admin_users: admin@cloudve.org
+        master_api_key: galaxypassword
+        single_user: admin@cloudve.org
+    "job_conf.yml":
+      runners:
+        k8s:
+          k8s_node_selector: "cloud.google.com/gke-nodepool: default-pool"
+  jobs:
+    rules:
+      # Used during development to ensure jobs will run on smaller instances
+      tpv_rules_local.yml:
+        destinations:
+          k8s:
+            max_cores: 2
+            # Memory must be an integer value, will be in Gi units
+            max_mem: 16
+  nodeSelector:
+    "cloud.google.com/gke-nodepool": "default-pool"
+  persistence:
+    storageClass: "nfs-gkmns"
+    size: "200Gi"
+  postgresql:
+    galaxyDatabasePassword: galaxypassword
+    # FIXME: nodeSelector is not working for postgresql?
+    # nodeSelector:
+    #   "cloud.google.com/gke-nodepool": "default-pool"
+    persistence:
+      storageClass: "nfs-gkmns"
+      size: 2Gi
+  rabbitmq:
+    nodeSelector:
+      "cloud.google.com/gke-nodepool": "default-pool"
+    persistence:
+      storageClassName: "nfs-gkmns"
+      # FIXME: Setting the size for rabbitmq is not working?
+      # size: 1Gi
+  ingress:
+    annotations: {}
+    ingressClassName: ""
+    tls: []
+
+nfs:
+  nodeSelector:
+    "cloud.google.com/gke-nodepool": "default-pool"
+  persistence:
+    existingClaim: "galaxy-nfs-pvc"
+  storageClass:
+    name: "nfs-gkmns"
+
+persistence:
+  nfs:
+    persistentVolume:
+      extraSpec:
+        gcePersistentDisk:
+          pdName: "nfs-pd"
+
+rbac:
+  serviceAccount: gkm-gkm-cm-svc-account

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -33,9 +33,9 @@ galaxy:
         affinity:
           nodeSelector:
             "cloud.google.com/gke-nodepool": "default-pool"
-    persistence:
-      storageClass: "nfs-gkmns"
-      size: 2Gi
+        storage:
+          pvcTemplate:
+            volumeName: "galaxy-postgres-pv"
   rabbitmq:
     nodeSelector:
       "cloud.google.com/gke-nodepool": "default-pool"
@@ -62,6 +62,11 @@ persistence:
       extraSpec:
         gcePersistentDisk:
           pdName: "nfs-pd"
+  postgres:
+    persistentVolume:
+      extraSpec:
+        csi:
+          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/postgres-pd"
 
 rbac:
   serviceAccount: gkm-gkm-cm-svc-account

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -26,16 +26,6 @@ galaxy:
   persistence:
     storageClass: "nfs-gkmns"
     size: "200Gi"
-  postgresql:
-    galaxyDatabasePassword: galaxypassword
-    operator:
-      operatorSpecExtra:
-        affinity:
-          nodeSelector:
-            "cloud.google.com/gke-nodepool": "default-pool"
-        storage:
-          pvcTemplate:
-            volumeName: "galaxy-postgres-pv"
   rabbitmq:
     nodeSelector:
       "cloud.google.com/gke-nodepool": "default-pool"
@@ -47,6 +37,11 @@ galaxy:
     annotations: {}
     ingressClassName: ""
     tls: []
+
+postgresql:
+  primary:
+    nodeSelector:
+      "cloud.google.com/gke-nodepool": "default-pool"
 
 nfs:
   nodeSelector:
@@ -65,8 +60,8 @@ persistence:
   postgres:
     persistentVolume:
       extraSpec:
-        csi:
-          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/postgres-pd"
+        gcePersistentDisk:
+          pdName: "postgres-pd"
 
 rbac:
   serviceAccount: gkm-gkm-cm-svc-account

--- a/galaxykubeman/templates/config-setup-galaxy.yaml
+++ b/galaxykubeman/templates/config-setup-galaxy.yaml
@@ -11,9 +11,13 @@ data:
   galaxy.yml: |
     {{- .Values.galaxy | toYaml | nindent 4 }}
   setup_galaxy.sh: |
-    helm repo add anvil {{ .Values.galaxy.chart.repository }}
+    echo "[`date`] Installing Postgres Helm chart..."
+    helm upgrade --install -n {{ .Release.Namespace }} {{ .Release.Name }}-postgres galaxy/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
+    helm repo add galaxy {{ .Values.galaxy.chart.repository }}
     helm repo update
-    helm template -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
-    helm upgrade --install -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
+    helm template -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy galaxy/galaxy -f /scripts/galaxy.yml --debug
+    echo "[`date`] Installing Galaxy Helm chart..."
+    helm upgrade --install -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy galaxy/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
+    echo "[`date`] Galaxy setup job complete."
   check_galaxy.sh: |
     if [ "$(helm status -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy | grep 'STATUS' | awk -F': ' '{print $2}')" = "deployed" ]; then exit 0; else exit 1; fi;

--- a/galaxykubeman/templates/config-setup-galaxy.yaml
+++ b/galaxykubeman/templates/config-setup-galaxy.yaml
@@ -13,6 +13,7 @@ data:
   setup_galaxy.sh: |
     helm repo add anvil {{ .Values.galaxy.chart.repository }}
     helm repo update
-    helm upgrade --install -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s
+    helm template -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
+    helm upgrade --install -n {{ .Release.Namespace }} --version {{ .Values.galaxy.version }} {{ .Release.Name }}-galaxy anvil/galaxy -f /scripts/galaxy.yml --wait --timeout=15m0s --debug
   check_galaxy.sh: |
     if [ "$(helm status -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy | grep 'STATUS' | awk -F': ' '{print $2}')" = "deployed" ]; then exit 0; else exit 1; fi;

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  backoffLimit: 0
   template:
     metadata:
       name: "{{ .Release.Name }}-pre-delete-job"
@@ -24,12 +25,16 @@ spec:
       containers:
       - name: pre-delete-kubectl
         image: "galaxy/cloudman-server:latest"
+        command: ["/bin/bash", "-c"]
+        env:
+          - name: CLUSTER_NAME
+            value: gkm-galaxy-postgres
         args:
-          - "sh"
-          - "-c"
-          - >
-            echo "[`date`] Deleting the galaxy deployment...";
-            helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
-            echo "[`date`] Deleting this pre-delete job...";
-            kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
-            echo "[`date`] Pre-delete job has completed.";
+          - |
+            echo "[`date`] Uninstalling Galaxy Helm release..."
+            helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait
+
+            echo "[`date`] Cleaning up old jobs..."
+            kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }}
+
+            echo "[`date`] Pre-delete job has completed."

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -30,8 +30,6 @@ spec:
           - >
             echo "[`date`] Deleting the galaxy deployment...";
             helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
-            echo "[`date`] Deleting the galaxy-deps deployment...";
-            helm uninstall -n {{ .Release.Namespace }} galaxy-deps --wait;
             echo "[`date`] Deleting this pre-delete job...";
             kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
             echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-setup-galaxy.yaml
+++ b/galaxykubeman/templates/job-setup-galaxy.yaml
@@ -8,6 +8,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   ttlSecondsAfterFinished: 600
+  backoffLimit: 0
   template:
     metadata:
       name: "{{ .Release.Name }}-setup-galaxy"

--- a/galaxykubeman/templates/persistence-restore.yaml
+++ b/galaxykubeman/templates/persistence-restore.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   finalizers:
     - kubernetes.io/pvc-protection
+  annotations:
+    meta.helm.sh/release-name: "{{ .Release.Name }}"
+    meta.helm.sh/release-namespace: "{{ .Release.Namespace }}"
 spec:
   storageClassName: "{{ .Values.galaxy.persistence.storageClass }}"
   accessModes:
@@ -49,7 +52,7 @@ spec:
   nfs:
     path: "/export/pvc-{{.Values.restore.persistence.nfs.galaxy.pvcID}}"
     server: "{{ .Release.Name }}-nfs.{{ .Release.Namespace }}.svc.cluster.local"
-  persistentVolumeReclaimPolicy: Retain
+  persistentVolumeReclaimPolicy: Delete
   storageClassName: "{{ .Values.galaxy.persistence.storageClass }}"
   accessModes:
     - {{ .Values.galaxy.persistence.accessMode }}

--- a/galaxykubeman/templates/persistence.yaml
+++ b/galaxykubeman/templates/persistence.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $entry := .Values.persistence -}}
 {{- if $entry -}}
+{{- if not (eq $key "postgres") -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -41,7 +42,7 @@ spec:
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
-
+{{ end -}}
 ---
 
 {{ if $entry.persistentVolume }}
@@ -85,9 +86,11 @@ spec:
     - {{ tpl $entry.accessMode $ | quote }}
   capacity:
     storage: {{ tpl $entry.size $ | quote }}
+  {{- if not (eq $key "postgres") }}
   claimRef:
     namespace: {{ $.Release.Namespace }}
     name: {{ tpl $entry.name $ }}-pvc
+  {{- end }}
   {{- if $entry.persistentVolume.extraSpec -}}
   {{- $original := (toYaml $entry.persistentVolume.extraSpec) -}}
   {{- $nomultiline := (regexReplaceAll "^^\\s*\\|\\n*" $original "") -}}

--- a/galaxykubeman/templates/persistence.yaml
+++ b/galaxykubeman/templates/persistence.yaml
@@ -1,6 +1,6 @@
 {{- range $key, $entry := .Values.persistence -}}
 {{- if $entry -}}
-{{- if not (eq $key "postgres") -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -42,11 +42,9 @@ spec:
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
-{{ end -}}
----
 
 {{ if $entry.persistentVolume }}
-
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -86,19 +84,15 @@ spec:
     - {{ tpl $entry.accessMode $ | quote }}
   capacity:
     storage: {{ tpl $entry.size $ | quote }}
-  {{- if not (eq $key "postgres") }}
   claimRef:
     namespace: {{ $.Release.Namespace }}
     name: {{ tpl $entry.name $ }}-pvc
-  {{- end }}
   {{- if $entry.persistentVolume.extraSpec -}}
   {{- $original := (toYaml $entry.persistentVolume.extraSpec) -}}
   {{- $nomultiline := (regexReplaceAll "^^\\s*\\|\\n*" $original "") -}}
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
-
----
 
 {{ end -}}
 {{- end -}}

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -32,16 +32,6 @@ persistence:
         gcePersistentDisk:
           # pdName: leo-created-pd
           fsType: ext4
-  postgres:
-    name: "galaxy-postgres"
-    size: "10Gi"
-    storageClass: "-"
-    accessMode: ReadWriteOnce
-    persistentVolume:
-      extraSpec:
-        gcePersistentDisk:
-          # pdName: leo-created-pd
-          fsType: ext4
 
 nfs:
   persistence:

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -98,7 +98,7 @@ galaxy:
     # existingClaim: "gkm-galaxy-galaxy-pvc"
     # storageClass: "-"
   postgresql:
-    enabled: false
+    deploy: false
     existingDatabase: gkm-postgresql
     galaxyDatabasePassword: galaxydbpassword
     galaxyExistingSecret: gkm-postgresql

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -14,11 +14,18 @@ restore:
         deployVolume: true
         # pvcID: pvc-uuid
 
+# This is the entry point for data persistence configuration. Existing
+# persistent disk need to be supplied here. PVCs and PVs are then created based
+# on this configuration.
 persistence:
   nfs:
-    name: "nfs-disk"
+    # Base name for the NFS PVC and PV
+    name: "galaxy-nfs"
+    # Size of the persistent volume from the infrastructure provider
     size: "250Gi"
-    storageClass: "manual"
+    # Unless using a StorageClass that will create appropriate backing storage
+    # (e.g., GCE PD, AWS EBS), this should be set to "-"
+    storageClass: "-"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -26,9 +33,9 @@ persistence:
           # pdName: leo-created-pd
           fsType: ext4
   postgres:
-    name: "postgres-disk"
+    name: "galaxy-postgres"
     size: "10Gi"
-    storageClass: "manual"
+    storageClass: "-"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -39,6 +46,7 @@ persistence:
 nfs:
   persistence:
     enabled: true
+    # WHAT DOES THIS DO?
     storageClass: "standard"
     size: "250Gi"
   storageClass:
@@ -49,10 +57,6 @@ nfs:
     mountOptions:
       - vers=4.2
       - noatime
-
-galaxy-deps:
-  cvmfs:
-    storageClassName: "cvmfs-{{ .Release.Namespace }}"
 
 galaxyInstallJob:
   readinessProbe:
@@ -70,10 +74,7 @@ galaxy:
       existingClass: "{{ .Release.Namespace }}-priority-class"
     maxRequests:
       cpu: 10
-      memory: 20 # in G
-    maxLimits:
-      cpu: 12
-      memory: 60 # in G
+      memory: 20 # in Gi
   image:
     repository: quay.io/galaxyproject/galaxy-min
     tag: "24.2-uid"
@@ -92,12 +93,6 @@ galaxy:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
     tls:
       - secretName: "tls-secret"
-  postgresql:
-    # nodeSelector: "cloud.google.com/gke-nodepool: good-pool"
-    persistence:
-      storageClass: "standard"
-  cvmfs:
-    storageClassName: "cvmfs-{{ .Release.Namespace }}"
   influxdb:
     enabled: false
   extraEnv: []
@@ -111,10 +106,6 @@ galaxy:
     ingress:
       tls:
         - secretName: "tls-secret"
-  rabbitmq:
-    deploy: false
-    persistence:
-      storageClassName: "standard"
   terra:
      launch:
         workspace: launchWorkspace

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -78,7 +78,7 @@ galaxyInstallJob:
     timeoutSeconds: 10
 
 galaxy:
-  version: 6.1.0
+  version: 6.2.0
   chart:
     repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
   jobs:
@@ -89,7 +89,7 @@ galaxy:
       memory: 20 # in Gi
   image:
     repository: quay.io/galaxyproject/galaxy-min
-    tag: "24.2-uid"
+    # tag: "25.0.rc1"
   persistence:
     accessMode: "ReadWriteMany"
     size: "240Gi"
@@ -402,7 +402,6 @@ galaxy:
       memory: 2G
       ephemeral-storage: 5Gi
     limits:
-      cpu: 2
       memory: 8G
       ephemeral-storage: 20Gi
   extraFileMappings:

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -12,7 +12,8 @@ restore:
     nfs:
       galaxy:
         deployVolume: true
-        # pvcID: pvc-uuid
+        # When pvcID is set, also must set galaxy.persistence.existingClaim
+        # pvcID: 57681430-eb8f-460f-9eae-294e061c579e
 
 # This is the entry point for data persistence configuration. Existing
 # persistent disk need to be supplied here. PVCs and PVs are then created based
@@ -30,18 +31,17 @@ persistence:
     persistentVolume:
       extraSpec:
         gcePersistentDisk:
-          # pdName: leo-created-pd
+          # pdName: leo-created-nfs-pd
           fsType: ext4
   postgres:
     name: "galaxy-postgres"
     size: "10Gi"
-    storageClass: "manual"
+    storageClass: "-"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
-        csi:
-          driver: pd.csi.storage.gke.io
-          # volumeHandle: "projects/{project_id}/zones/us-east1-b/disks/{disk_name}"
+        gcePersistentDisk:
+          # pdName: leo-created-pg-pd
           fsType: ext4
 
 nfs:
@@ -58,6 +58,17 @@ nfs:
     mountOptions:
       - vers=4.2
       - noatime
+
+postgresql:
+  auth:
+    username: galaxydbuser
+    password: galaxydbpassword
+    database: galaxy
+  primary:
+    size: 10Gi
+    storageClass: "manual"
+    persistence:
+      existingClaim: "galaxy-postgres-pvc"
 
 galaxyInstallJob:
   readinessProbe:
@@ -81,22 +92,18 @@ galaxy:
     tag: "24.2-uid"
   persistence:
     accessMode: "ReadWriteMany"
-    storageClass: "nfs-{{ .Release.Namespace }}"
     size: "240Gi"
-    # existingClaim: "{{ .Release.Name }}-galaxy-pvc"
+    storageClass: "nfs-{{ .Release.Namespace }}"
+    # If existingClaim it set, also set storageClass to "-"
+    # existingClaim: "gkm-galaxy-galaxy-pvc"
+    # storageClass: "-"
   postgresql:
-    operator:
-      operatorSpecExtra:
-        storage:
-          size: 10Gi
-          pvcTemplate:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 10Gi
-            volumeName: "galaxy-postgres-pv"
-            storageClassName: "manual"
+    enabled: false
+    existingDatabase: gkm-postgresql
+    galaxyDatabasePassword: galaxydbpassword
+    galaxyExistingSecret: gkm-postgresql
+    galaxyExistingSecretKeyRef: password
+    galaxyConnectionParams: ""
   ingress:
     enabled: true
     annotations:

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -32,6 +32,17 @@ persistence:
         gcePersistentDisk:
           # pdName: leo-created-pd
           fsType: ext4
+  postgres:
+    name: "galaxy-postgres"
+    size: "10Gi"
+    storageClass: "manual"
+    accessMode: ReadWriteOnce
+    persistentVolume:
+      extraSpec:
+        csi:
+          driver: pd.csi.storage.gke.io
+          # volumeHandle: "projects/{project_id}/zones/us-east1-b/disks/{disk_name}"
+          fsType: ext4
 
 nfs:
   persistence:
@@ -73,6 +84,19 @@ galaxy:
     storageClass: "nfs-{{ .Release.Namespace }}"
     size: "240Gi"
     # existingClaim: "{{ .Release.Name }}-galaxy-pvc"
+  postgresql:
+    operator:
+      operatorSpecExtra:
+        storage:
+          size: 10Gi
+          pvcTemplate:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10Gi
+            volumeName: "galaxy-postgres-pv"
+            storageClassName: "manual"
   ingress:
     enabled: true
     annotations:


### PR DESCRIPTION
Update the configs and documentation so that the Galaxy dependencies are installed separately from GKM. The deps should be installed cluster-wide, as Operators are supposed to be. The Galaxy chart will rely on those to instantiate necessary resources. Among following best practices, this now allows multiple instances of GKM/Galaxy to be installed on the same cluster, each in separate nodepool/namespace. 

~One outstanding issue is the the Postgres Cluster pod does not respect `nodeSelector` so it is not getting scheduled on the same node as the rest of the Galaxy deployment.~ Fixed in https://github.com/galaxyproject/galaxykubeman-helm/pull/89/commits/7d455bf7fc826980d25f2d258ed1cf66d9757ab7.