### PR TITLE
Try using the exiting pgdata directory to resume Postgresql

### DIFF
--- a/galaxykubeman/restore.yml
+++ b/galaxykubeman/restore.yml
@@ -1,17 +1,9 @@
 galaxy:
   persistence:
     existingClaim: gkm-galaxy-galaxy-pvc
-  postgresql:
-    recovery:
-      enabled: true
-      path: gs://ks-anvil-bucket
-    backup:
-      enabled: false
-      path: gs://ks-anvil-bucket
-#      snapshot: galaxy-snapshot-1
 restore:
   persistence:
     nfs:
       galaxy:
         deployVolume: true
-        pvcID: adc6c4c8-c983-4985-8255-6bb4e8f6df6c
+        pvcID: e6a42a35-ddfb-47d1-bc37-f4fc1b25d36d

--- a/galaxykubeman/restore.yml
+++ b/galaxykubeman/restore.yml
@@ -2,8 +2,9 @@ galaxy:
   persistence:
     existingClaim: gkm-galaxy-galaxy-pvc
 restore:
+  postgres: true
   persistence:
     nfs:
       galaxy:
         deployVolume: true
-        pvcID: e6a42a35-ddfb-47d1-bc37-f4fc1b25d36d
+        pvcID: 9729a935-e1c1-4c23-ae3b-d64d4fda954d

--- a/galaxykubeman/restore.yml
+++ b/galaxykubeman/restore.yml
@@ -1,0 +1,17 @@
+galaxy:
+  persistence:
+    existingClaim: gkm-galaxy-galaxy-pvc
+  postgresql:
+    recovery:
+      enabled: true
+      path: gs://ks-anvil-bucket
+    backup:
+      enabled: false
+      path: gs://ks-anvil-bucket
+#      snapshot: galaxy-snapshot-1
+restore:
+  persistence:
+    nfs:
+      galaxy:
+        deployVolume: true
+        pvcID: adc6c4c8-c983-4985-8255-6bb4e8f6df6c

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -33,6 +33,7 @@ galaxy:
     storageClass: "nfs-gkmns"
     size: "200Gi"
   postgresql:
+    postgresqlPostgresPassword: postgres
     galaxyDatabasePassword: galaxypassword
     recovery:
       enabled: false

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -48,7 +48,6 @@ galaxy:
             "cloud.google.com/gke-nodepool": "default-pool"
         storage:
           pvcTemplate:
-            storageClassName: "standard"
             volumeName: "galaxy-postgres-pv"
   rabbitmq:
     nodeSelector:

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -1,7 +1,4 @@
 galaxy:
-  version: '6.1.1'
-  chart:
-    repository: https://ksuderman.github.io/helm_charts
   service:
     type: LoadBalancer
     port: 80
@@ -35,12 +32,6 @@ galaxy:
   postgresql:
     postgresqlPostgresPassword: postgres
     galaxyDatabasePassword: galaxypassword
-    recovery:
-      enabled: false
-      path: gs://ks-anvil-bucket
-    backup:
-      enabled: true
-      path: gs://ks-anvil-bucket
     operator:
       operatorSpecExtra:
         affinity:

--- a/galaxykubeman/sample-values.yaml
+++ b/galaxykubeman/sample-values.yaml
@@ -1,7 +1,13 @@
 galaxy:
+  version: '6.1.1'
+  chart:
+    repository: https://ksuderman.github.io/helm_charts
   service:
     type: LoadBalancer
     port: 80
+  serviceAccount:
+    annotations:
+      iam.gke.io/gcp-service-account: cnpg-backup-sa@anvil-and-terra-development.iam.gserviceaccount.com
   configs:
     "galaxy.yml":
       galaxy:
@@ -28,6 +34,12 @@ galaxy:
     size: "200Gi"
   postgresql:
     galaxyDatabasePassword: galaxypassword
+    recovery:
+      enabled: false
+      path: gs://ks-anvil-bucket
+    backup:
+      enabled: true
+      path: gs://ks-anvil-bucket
     operator:
       operatorSpecExtra:
         affinity:
@@ -35,6 +47,7 @@ galaxy:
             "cloud.google.com/gke-nodepool": "default-pool"
         storage:
           pvcTemplate:
+            storageClassName: "standard"
             volumeName: "galaxy-postgres-pv"
   rabbitmq:
     nodeSelector:
@@ -61,12 +74,12 @@ persistence:
     persistentVolume:
       extraSpec:
         gcePersistentDisk:
-          pdName: "nfs-pd"
+          pdName: "ks-nfs-pd"
   postgres:
     persistentVolume:
       extraSpec:
         csi:
-          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/postgres-pd"
+          volumeHandle: "projects/anvil-and-terra-development/zones/us-east1-b/disks/ks-postgres-pd"
 
 rbac:
   serviceAccount: gkm-gkm-cm-svc-account

--- a/galaxykubeman/templates/_helpers.yml
+++ b/galaxykubeman/templates/_helpers.yml
@@ -55,3 +55,23 @@ Get default value or max
     {{- .default | int }}
   {{- end }}
 {{- end }}
+
+{{- define "galaxykubeman.hibernate-cluster" -}}
+start_time=$SECONDS
+cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}')
+kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on
+echo "Waiting for cluster $cluster  to hibernate"
+while true; do
+  # Check if "cnpg.io/hibernation" condition is present and status is True
+  status=$(kubectl get cluster $cluster -n {{ .Release.Namespace }} -o jsonpath='{.status.conditions[?(@.type=="cnpg.io/hibernation")].status}')
+  if [ "$status" = "True" ]; then
+      echo "Cluster $cluster is now hibernated."
+      break
+  fi
+  sleep 5
+done
+echo
+dt=$(( SECONDS - start_time ))
+printf "Hibernation took %d:%02d\n" $(( dt / 60 )) $(( dt % 60 ))
+{{- end }}
+

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -35,6 +35,8 @@ spec:
             sleep 20
             echo "[`date`] Deleting the galaxy deployment...";
             helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
+            sleep 5;
+            kubectl get pv | grep galaxy-pvc | awk '{print $1}' | xargs kubectl delete pv;
             echo "[`date`] Deleting this pre-delete job...";
             kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
             echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -11,7 +12,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       name: "{{ .Release.Name }}-pre-delete-job"
@@ -26,17 +27,38 @@ spec:
       - name: pre-delete-kubectl
         image: "galaxy/cloudman-server:latest"
         args:
-          - "sh"
-          - "-c"
-          - >
-            echo "[`date`] Hibernating the postgres cluster...";
-            cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}');
-            kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on;
-            sleep 20
-            echo "[`date`] Deleting the galaxy deployment...";
-            helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
-            sleep 5;
-            kubectl get pv | grep galaxy-pvc | awk '{print $1}' | xargs kubectl delete pv;
-            echo "[`date`] Deleting this pre-delete job...";
-            kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
-            echo "[`date`] Pre-delete job has completed.";
+          - "bash"
+          - "/scripts/delete.sh"
+        volumeMounts:
+          - name: galaxy-conf-files
+            mountPath: /scripts
+      volumes:
+        - name: galaxy-conf-files
+          configMap:
+            name: "{{ .Release.Name }}-pre-delete-script"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pre-delete-script
+  labels:
+    app.kubernetes.io/name: {{ include "galaxykubeman.name" . }}
+    helm.sh/chart: {{ include "galaxykubeman.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  delete.sh: |
+    echo "[`date`] Hibernating the postgres cluster..."
+    {{- include "galaxykubeman.hibernate-cluster" . | nindent 4 }}
+    echo "[`date`] Deleting the galaxy deployment...";
+    helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
+    sleep 5;
+    for pv in $(kubectl get pv -o jsonpath='{.items[?(@.status.phase=="Released")].metadata.name}'); do
+      echo "[`date`] Deleting the persistent volume $pv...";
+      kubectl patch pv $pv -p '{"metadata":{"finalizers":null}}';
+      kubectl delete pv $pv;
+    done
+    kubectl delete namespace {{ .Release.Namespace }};
+    echo "[`date`] Deleting this pre-delete job...";
+    kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
+    echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -32,9 +32,9 @@ spec:
             echo "[`date`] Hibernating the postgres cluster...";
             cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}');
             kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on;
+            sleep 20
             echo "[`date`] Deleting the galaxy deployment...";
             helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
             echo "[`date`] Deleting this pre-delete job...";
-            kubectl get job -n {{ .Release.Namespace }} -o name;
             kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
             echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -11,6 +11,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 600
   template:
     metadata:
       name: "{{ .Release.Name }}-pre-delete-job"
@@ -28,8 +29,12 @@ spec:
           - "sh"
           - "-c"
           - >
+            echo "[`date`] Hibernating the postgres cluster...";
+            cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}');
+            kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on;
             echo "[`date`] Deleting the galaxy deployment...";
             helm uninstall -n {{ .Release.Namespace }} {{ .Release.Name }}-galaxy --wait;
             echo "[`date`] Deleting this pre-delete job...";
+            kubectl get job -n {{ .Release.Namespace }} -o name;
             kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
             echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-predelete.yaml
+++ b/galaxykubeman/templates/job-predelete.yaml
@@ -58,7 +58,6 @@ data:
       kubectl patch pv $pv -p '{"metadata":{"finalizers":null}}';
       kubectl delete pv $pv;
     done
-    kubectl delete namespace {{ .Release.Namespace }};
     echo "[`date`] Deleting this pre-delete job...";
     kubectl get job -n {{ .Release.Namespace }} -o name | grep -v "pre-delete" | xargs kubectl delete -n {{ .Release.Namespace }};
     echo "[`date`] Pre-delete job has completed.";

--- a/galaxykubeman/templates/job-resume-galaxy.yaml
+++ b/galaxykubeman/templates/job-resume-galaxy.yaml
@@ -59,6 +59,7 @@ data:
     echo "Hibernating cluster"
     cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}')
     kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on
+    sleep 20
     cd /var/lib/postgresql/data
     pwd
     ls -alh

--- a/galaxykubeman/templates/job-resume-galaxy.yaml
+++ b/galaxykubeman/templates/job-resume-galaxy.yaml
@@ -1,0 +1,81 @@
+{{ if .Values.restore.postgres -}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-resume-galaxy"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-resume-galaxy"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: "{{ .Values.rbac.serviceAccount }}"
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: kubectl-galaxy-resume
+        image: "galaxy/cloudman-server:latest"
+        args:
+          - "sh"
+          - "/scripts/restore_database.sh"
+        volumeMounts:
+          - name: galaxy-conf-files
+            mountPath: /scripts
+          - name: postgres-pvc
+            mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: galaxy-conf-files
+          configMap:
+            name: "{{ .Release.Name }}-resume"
+        - name: postgres-pvc
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-galaxy-postgres-1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-resume
+  labels:
+    app.kubernetes.io/name: {{ include "galaxykubeman.name" . }}
+    helm.sh/chart: {{ include "galaxykubeman.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  restore_database.sh: |
+    echo "Waiting for all deployments to be ready"
+    for deployment in $(kubectl get deployments -n {{ .Release.Namespace }} -o jsonpath='{.items[*].metadata.name}') ; do
+      kubectl rollout status deployment $deployment -n {{ .Release.Namespace }} --timeout=15m0s --watch
+    done
+    echo "Hibernating cluster"
+    cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}')
+    kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on
+    cd /var/lib/postgresql/data
+    pwd
+    ls -alh
+    existing=$(find . -name "pgdata_*" -type d -print -quit)
+    if [ -z "$existing" ]; then
+      echo "No existing backup found"
+      exit 1
+    fi
+    echo "Removing the new pgdata"
+    if [ ! -e backups ] ; then
+        mkdir backups
+    fi
+    mv pgdata backups/pgdata_$(date +%Y%m%dT%H%M%SZ)
+    echo "Restoring backup: $existing"
+    mv $existing pgdata
+    ls -alh
+    echo "Resuming cluster"
+    kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=off
+    echo "Done."
+    {{- end }}

--- a/galaxykubeman/templates/job-resume-galaxy.yaml
+++ b/galaxykubeman/templates/job-resume-galaxy.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.restore.postgres -}}
+{{ if .Values.restore.persistence.nfs.galaxy.pvcID -}}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/galaxykubeman/templates/job-resume-galaxy.yaml
+++ b/galaxykubeman/templates/job-resume-galaxy.yaml
@@ -26,7 +26,7 @@ spec:
       - name: kubectl-galaxy-resume
         image: "galaxy/cloudman-server:latest"
         args:
-          - "sh"
+          - "bash"
           - "/scripts/restore_database.sh"
         volumeMounts:
           - name: galaxy-conf-files
@@ -57,9 +57,7 @@ data:
       kubectl rollout status deployment $deployment -n {{ .Release.Namespace }} --timeout=15m0s --watch
     done
     echo "Hibernating cluster"
-    cluster=$(kubectl get cluster -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}')
-    kubectl annotate cluster $cluster -n {{ .Release.Namespace }} --overwrite cnpg.io/hibernation=on
-    sleep 20
+    {{- include "galaxykubeman.hibernate-cluster" . | nindent 4 }}
     cd /var/lib/postgresql/data
     pwd
     ls -alh
@@ -72,7 +70,7 @@ data:
     if [ ! -e backups ] ; then
         mkdir backups
     fi
-    mv pgdata backups/pgdata_$(date +%Y%m%dT%H%M%SZ)
+    mv pgdata backups/$(date +%Y%m%dT%H%M%SZ)
     echo "Restoring backup: $existing"
     mv $existing pgdata
     ls -alh

--- a/galaxykubeman/templates/persistence-restore.yaml
+++ b/galaxykubeman/templates/persistence-restore.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.restore.persistence.nfs.galaxy.pvcID -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,14 +14,14 @@ metadata:
 spec:
   storageClassName: "{{ .Values.galaxy.persistence.storageClass }}"
   accessModes:
-    - '{{ .Values.galaxy.persistence.accessMode }}'
+    - {{ .Values.galaxy.persistence.accessMode }}
   resources:
     requests:
       storage: {{ .Values.galaxy.persistence.size | quote }}
   volumeMode: Filesystem
   volumeName: "pvc-{{.Values.restore.persistence.nfs.galaxy.pvcID}}"
----
 {{ if .Values.restore.persistence.nfs.galaxy.deployVolume -}}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -58,6 +59,6 @@ spec:
   claimRef:
     namespace: {{ .Release.Namespace }}
     name: {{ .Release.Name }}-galaxy-galaxy-pvc
----
+
 {{ end -}}
 {{ end -}}

--- a/galaxykubeman/templates/persistence.yaml
+++ b/galaxykubeman/templates/persistence.yaml
@@ -1,6 +1,7 @@
 {{- range $key, $entry := .Values.persistence -}}
 {{- if $entry -}}
 {{- if not (eq $key "postgres") -}}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -43,10 +44,9 @@ spec:
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
 {{ end -}}
----
 
 {{ if $entry.persistentVolume }}
-
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -97,8 +97,6 @@ spec:
   {{- $nowhitespace := (regexReplaceAll "{{\\s*([^}\\s]+)\\s*}}" $nomultiline "{{$1}}") -}}
   {{- tpl $nowhitespace $ | trim | nindent 2 -}}
   {{- end }}
-
----
 
 {{ end -}}
 {{- end -}}

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -25,7 +25,7 @@ persistence:
     size: "250Gi"
     # Unless using a StorageClass that will create appropriate backing storage
     # (e.g., GCE PD, AWS EBS), this should be set to "-"
-    storageClass: "standard"
+    storageClass: "-"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -35,7 +35,7 @@ persistence:
   postgres:
     name: "galaxy-postgres"
     size: "10Gi"
-    storageClass: "standard"
+    storageClass: "manual"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -97,7 +97,7 @@ galaxy:
               requests:
                 storage: 10Gi
             volumeName: "galaxy-postgres-pv"
-            storageClassName: "standard"
+            storageClassName: "manual"
   ingress:
     enabled: true
     annotations:

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -25,7 +25,7 @@ persistence:
     size: "250Gi"
     # Unless using a StorageClass that will create appropriate backing storage
     # (e.g., GCE PD, AWS EBS), this should be set to "-"
-    storageClass: "-"
+    storageClass: "standard"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -35,7 +35,7 @@ persistence:
   postgres:
     name: "galaxy-postgres"
     size: "10Gi"
-    storageClass: "manual"
+    storageClass: "standard"
     accessMode: ReadWriteOnce
     persistentVolume:
       extraSpec:
@@ -52,7 +52,7 @@ nfs:
     size: "250Gi"
   storageClass:
     create: true
-    defaultClass: true
+    defaultClass: false
     allowVolumeExpansion: true
     reclaimPolicy: "Retain"
     mountOptions:
@@ -96,7 +96,7 @@ galaxy:
               requests:
                 storage: 10Gi
             volumeName: "galaxy-postgres-pv"
-            storageClassName: "manual"
+            storageClassName: "standard"
   ingress:
     enabled: true
     annotations:

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -67,9 +67,10 @@ galaxyInstallJob:
     timeoutSeconds: 10
 
 galaxy:
-  version: 6.1.0
+  version: 6.1.1
   chart:
-    repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
+    #repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
+    repository: https://ksuderman.github.io/helm_charts
   jobs:
     priorityClass:
       existingClass: "{{ .Release.Namespace }}-priority-class"

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -67,10 +67,10 @@ galaxyInstallJob:
     timeoutSeconds: 10
 
 galaxy:
-  version: 6.1.1
+  version: 6.1.0
   chart:
-    #repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
-    repository: https://ksuderman.github.io/helm_charts
+    repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
+#    repository: https://ksuderman.github.io/helm_charts
   jobs:
     priorityClass:
       existingClass: "{{ .Release.Namespace }}-priority-class"


### PR DESCRIPTION
When the CNPG operator starts a Postgres cluster and finds an existing `pgdata` directory it does not re-use the existing directory; rather it renames the existing `pgdata` directory and creates a new, empty, database in a new `pgdata` directory.  The existing data is retained, Postgres just refuses to use it.

This pull-request gets Postgres to re-use an existing `pgdata` directory by doing two things:
1. During shutdown, I.e. in `job-predelete.yaml` the Postgres cluster is put into *hibernation* mode. I am not absolutely sure this step is required, but since we will be taking this database out of hibernation mode when restoring the cluster is seems like a prudent thing to do.  We can test this later if needed.
2. Adding a job (`job-resume-galaxy.yaml`)  that is run when resuming a *paused* Galaxy instance, that is, when `.Values.restore.persistence.nfs.galaxy.pvcID` is defined. Terra will define this key when starting a Galaxy instance that is reusing existing disks. The resume galaxy job:
- waits until the deployment is complete
- hibernates the Postgres cluster
- renames the `pgdata` directories
- un-hibernates the cluster

While this approach has been tricky to get working, its big advantage is that it does not require any changes to the Postgres cluster configuration, changes to other Helm charts, and no changes to Leo.

## Caveats and known issues

For reasons that are not currently clear to me, the Helm pre-delete hook (`job-predelete.yaml`) succeeds the first time it is run, but hangs on subsequent runs on the same cluster.  For some reason several PVs remain bound to PVCs, and the NFS server pod won't go away.  If it is deleted manually the Ganesha operator just resurrects it.  The current *hackaround* is to:
- `kubectl patch` each PV to clear the `finalizers` field
- explicitly `kubectl delete` each *Released* PV (which should be all of them)
- `kubectl delete` the `.Release.Namespace`

Kubernetes/Helm is unhappy when the namespace is deleted as part of the `pre-delete` hook. Or at least `helm uninstall` returns with the error *"Error: uninstallation completed with 1 error(s): uninstall: Failed to purge the release: release: not found"*. Maybe we could get Leo to do a `kubectl delete namespace` after the `helm uninstall`?

