### PR TITLE
Add a patch job for making the NFS service LoadBalancer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Start by launching a GKE cluster, then install the Galaxy dependencies chart tha
 necessary operators, as well as create persistent disks.
 
 ```console
-gcloud container clusters create example-gke-cluster --cluster-version="1.30" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
+gcloud container clusters create example-gke-cluster --cluster-version="1.31" --no-enable-autorepair --disk-size=200 --num-nodes=1 --machine-type=e2-standard-16 --zone "us-east1-b"
 
 
 helm repo add cloudve https://raw.githubusercontent.com/CloudVE/helm-charts/master/
@@ -89,6 +89,15 @@ helm upgrade --install --create-namespace -n gkmns2 gkm2 . --values sample-value
 It will take a few minutes for the second Galaxy instance to be ready. The
 instance will be deployed It will be available at http://[galaxy-nginx-2 service
 external IP]/galaxy/.
+
+## Deleting a deployment
+
+To delete a Galaxy instance, you can run the following command. The GKM chart
+has a job that will delete the Galaxy chart.
+
+```console
+helm uninstall -n gkmns gkm
+```
 
 ## Leo updates
 When the GKM chart version changes, need to make a PR to

--- a/galaxykubeman/templates/_helpers.yml
+++ b/galaxykubeman/templates/_helpers.yml
@@ -55,3 +55,23 @@ Get default value or max
     {{- .default | int }}
   {{- end }}
 {{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "galaxykubeman.labels" -}}
+helm.sh/chart: {{ include "galaxykubeman.chart" . }}
+{{ include "galaxykubeman.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "galaxykubeman.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "galaxykubeman.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/galaxykubeman/templates/nfs-lb-patcher.yaml
+++ b/galaxykubeman/templates/nfs-lb-patcher.yaml
@@ -1,0 +1,127 @@
+# Patch NFS Service to use LoadBalancer with TCP-only ports and Internal annotation
+# This job will run after the NFS service is created.
+# This is required to deploy on GCP because GCP LBs do not support mixing of protocols in the same LB.
+# Meanwhile, in order for a GCP Batch job to mount the NFS service, it needs to be a LoadBalancer type service.
+{{- if .Values.nfs.service.type }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-lb-patcher"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "galaxykubeman.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-timeout": "900"  # Keep job for 15 minutes (900 seconds)
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "galaxykubeman.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+      restartPolicy: Never
+      containers:
+      - name: nfs-lb-patcher
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          echo "Waiting for NFS service to be created..."
+
+          # Discover NFS service by labels from the NFS chart
+          timeout=300
+          interval=5
+          elapsed=0
+
+          while [ $elapsed -lt $timeout ]; do
+            SERVICE_NAME=$(kubectl get service -l "app=nfs,release={{ .Release.Name }}" -n {{ .Release.Namespace }} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+            if [ -n "$SERVICE_NAME" ]; then
+              echo "NFS service found: $SERVICE_NAME"
+              break
+            fi
+            echo "Waiting for NFS service with labels 'app=nfs,release={{ .Release.Name }}'... ($elapsed/$timeout seconds)"
+            sleep $interval
+            elapsed=$((elapsed + interval))
+          done
+
+          if [ $elapsed -ge $timeout ]; then
+            echo "ERROR: NFS service with labels 'app=nfs,release={{ .Release.Name }}' not found after $timeout seconds"
+            exit 1
+          fi
+
+          # Patch the service to use LoadBalancer with only TCP ports and Internal annotation
+          kubectl patch service "$SERVICE_NAME" -n {{ .Release.Namespace }} --type='merge' -p='{
+            "spec": {
+              "type": "LoadBalancer",
+              "ports": [
+                {
+                  "name": "nfs",
+                  "port": 2049,
+                  "protocol": "TCP",
+                  "targetPort": 2049
+                },
+                {
+                  "name": "mountd",
+                  "port": 20048,
+                  "protocol": "TCP",
+                  "targetPort": 20048
+                }
+              ]
+            },
+            "metadata": {
+              "annotations": {
+                "cloud.google.com/load-balancer-type": "Internal"
+              }
+            }
+          }'
+
+          echo "Successfully patched NFS service $SERVICE_NAME to use Internal LoadBalancer with TCP-only ports"
+
+          # Wait for LoadBalancer IP to be assigned
+          echo "Waiting for LoadBalancer IP assignment..."
+
+          # Use a more robust approach to wait for LB IP
+          lb_timeout=300
+          lb_interval=10
+          lb_elapsed=0
+
+          while [ $lb_elapsed -lt $lb_timeout ]; do
+            LB_IP=$(kubectl get service "$SERVICE_NAME" -n {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "")
+            if [ -n "$LB_IP" ] && [ "$LB_IP" != "" ]; then
+              echo "LoadBalancer IP assigned: $LB_IP"
+              break
+            fi
+            echo "Waiting for LoadBalancer IP... ($lb_elapsed/$lb_timeout seconds)"
+            sleep $lb_interval
+            lb_elapsed=$((lb_elapsed + lb_interval))
+          done
+
+          # Get the final IP status
+          LB_IP=$(kubectl get service "$SERVICE_NAME" -n {{ .Release.Namespace }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || echo "Pending")
+          echo "LoadBalancer IP: $LB_IP"
+
+          # Verify the patch was applied
+          echo "Verifying patch..."
+          echo "Service type:"
+          kubectl get service "$SERVICE_NAME" -n {{ .Release.Namespace }} -o jsonpath='{.spec.type}'
+          echo ""
+          echo "Service ports:"
+          kubectl get service "$SERVICE_NAME" -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports}' | jq .
+          echo ""
+          echo "Service annotations:"
+          kubectl get service "$SERVICE_NAME" -n {{ .Release.Namespace }} -o jsonpath='{.metadata.annotations}' | jq .
+          echo ""
+
+          echo "NFS LoadBalancer setup completed successfully"
+          if [ "$LB_IP" != "Pending" ]; then
+            echo "External clients can now mount using: $LB_IP:2049"
+          else
+            echo "LoadBalancer IP still pending - check service status manually"
+          fi
+{{- end }}

--- a/galaxykubeman/templates/nfs-rbac-patcher.yaml
+++ b/galaxykubeman/templates/nfs-rbac-patcher.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.nfs.service.type }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "galaxykubeman.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "galaxykubeman.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "galaxykubeman.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+subjects:
+- kind: ServiceAccount
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: "{{ include "galaxykubeman.fullname" . }}-nfs-patcher"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/galaxykubeman/values.yaml
+++ b/galaxykubeman/values.yaml
@@ -45,6 +45,8 @@ persistence:
           fsType: ext4
 
 nfs:
+  service:
+    type: ClusterIP  # Will be changed to LoadBalancer by the patcher job
   persistence:
     enabled: true
     # WHAT DOES THIS DO?
@@ -58,6 +60,11 @@ nfs:
     mountOptions:
       - vers=4.2
       - noatime
+      - retrans=2
+      - timeo=30
+      - lock        # Enable NFS locking
+      - hard        # Ensure reliable locking
+      - proto=tcp   # Force TCP protocol to avoid UDP issues
 
 postgresql:
   auth:
@@ -78,7 +85,7 @@ galaxyInstallJob:
     timeoutSeconds: 10
 
 galaxy:
-  version: 6.2.0
+  version: 6.2.1
   chart:
     repository: https://raw.githubusercontent.com/cloudve/helm-charts/master/
   jobs:


### PR DESCRIPTION
GCP LoadBalancers (LB) cannot have a mix of protocol types, which is all NFS Ganesha chart supports. This patch job changes the ports exposed by the NFS Service manifest to use only TCP and switches the service type to (an internal) LB. This is all so a GCP Batch job can mount Galaxy's NFS.